### PR TITLE
migrate: re-run post-step callbacks on error

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -866,22 +866,28 @@ func (m *Migrate) execProgrammaticMigration(migr *Migration) error {
 		return err
 	}
 
-	err = programmaticMigration(migr, m.databaseDrv)
+	err = programmaticMigration.ProgrammaticMigr(migr, m.databaseDrv)
 	if err != nil {
-		// Reset the version to the version set before executing the
-		// programmatic migration. Therefore, the programmatic migration
-		// will be re-executed on the next startup until it succeeds.
-		setErr := m.databaseDrv.SetVersion(curVersion, false)
-		if setErr != nil {
-			// Note that if we error here, the database version will
-			// remain in a dirty state. As we cannot know if the
-			// programmatic migration was executed or not in that
-			// scenario, manual intervention is required.
-			return fmt.Errorf("WARNING, failed to set migration "+
-				"version after programmatic migration "+
-				"errored. Manual intervention needed! "+
-				"Programmatic migration error: %w, version "+
-				"setting error : %w", err, setErr)
+		// If the programmatic migration should be re-run on the next
+		// startup, we reset the version to the version set before
+		// executing the programmatic migration. Therefore, the
+		// programmatic migration will effectively be re-executed on the
+		// next startup until it succeeds.
+		if programmaticMigration.ResetVersionOnError {
+			setErr := m.databaseDrv.SetVersion(curVersion, false)
+			if setErr != nil {
+				// Note that if we error here, the database
+				// version will remain in a dirty state. As we
+				// cannot know if the programmatic migration was
+				// executed or not in that scenario, manual
+				// intervention is required.
+				return fmt.Errorf("WARNING, failed to set "+
+					"migration version after programmatic "+
+					"migration errored. Manual "+
+					"intervention needed! Programmatic "+
+					"migration error: %w, version setting "+
+					"error : %w", err, setErr)
+			}
 		}
 
 		return fmt.Errorf("failed to execute programmatic migration: "+

--- a/migrate.go
+++ b/migrate.go
@@ -28,12 +28,19 @@ var DefaultPrefetchMigrations = uint(10)
 // DefaultLockTimeout sets the max time a database driver has to acquire a lock.
 var DefaultLockTimeout = 15 * time.Second
 
+// classifyPeekLimit caps how many bytes we read of a migration when
+// classifying if it contains an SQL migration or not.
+// The cap is set to 128 KB.
+const classifyPeekLimit = 128 * 1024
+
 var (
 	ErrNoChange       = errors.New("no change")
 	ErrNilVersion     = errors.New("no migration")
 	ErrInvalidVersion = errors.New("version must be >= -1")
 	ErrLocked         = errors.New("database locked")
 	ErrLockTimeout    = errors.New("timeout: can't acquire database lock")
+	ErrMixedMigration = errors.New("migration has both an SQL migration " +
+		"and a programmatic migration set")
 )
 
 // ErrShortLimit is an error returned when not enough migrations
@@ -752,37 +759,55 @@ func (m *Migrate) runMigrations(ret <-chan interface{}) error {
 		case *Migration:
 			migr := r
 
-			// set version with dirty state
-			if err := m.databaseDrv.SetVersion(migr.TargetVersion, true); err != nil {
-				return err
-			}
-
 			if migr.Body != nil {
-				m.logVerbosePrintf("Read and execute %v\n", migr.LogString())
-				if err := m.databaseDrv.Run(migr.BufferedBody); err != nil {
+				// Check if the migration contains an SQL
+				// migration.
+				hasSqlMig, err := classifyMigrationBody(
+					migr, classifyPeekLimit,
+				)
+				if err != nil {
 					return err
 				}
 
-				migrVer := migr.Version
+				ver := migr.Version
 
-				// If there is a programmatic migration function
-				// for this migration, run it now.
-				cb, ok := m.opts.programmaticMigrations[migrVer]
-				if ok {
-					m.logVerbosePrintf("Running "+
-						"programmatic migration for "+
-						"%v\n", migr.LogString())
+				// Check if the migration contains a
+				// programmatic migration.
+				_, hasPMig := m.opts.programmaticMigrations[ver]
 
-					err := cb(migr, m.databaseDrv)
-					if err != nil {
-						return fmt.Errorf("failed to "+
-							"execute programmatic "+
-							"migration: %w", err)
+				// Execute the SQL migration or the programmatic
+				// migration.
+				switch {
+				case hasSqlMig && hasPMig:
+					return ErrMixedMigration
+
+				case hasSqlMig:
+					if err = m.databaseDrv.SetVersion(migr.TargetVersion, true); err != nil {
+						return err
 					}
 
-					m.logVerbosePrintf("Programmatic"+
-						"migration finished for "+
-						"%v\n", migr.LogString())
+					m.logVerbosePrintf("Read and execute %v\n", migr.LogString())
+					if err = m.databaseDrv.Run(migr.BufferedBody); err != nil {
+						return err
+					}
+
+				case hasPMig:
+					err = m.execProgrammaticMigration(migr)
+					if err != nil {
+						return fmt.Errorf("execution "+
+							"of programmatic "+
+							"migration failed: "+
+							"%w", err)
+					}
+
+				default:
+					// When the migration contains no SQL
+					// migration or programmatic migration,
+					// we continue and set the version to
+					// the migr.TargetVersion.
+					m.logVerbosePrintf("Warning: "+
+						"Contentless migration "+
+						"executed at version %d!", ver)
 				}
 			}
 
@@ -808,6 +833,64 @@ func (m *Migrate) runMigrations(ret <-chan interface{}) error {
 			return fmt.Errorf("unknown type: %T with value: %+v", r, r)
 		}
 	}
+	return nil
+}
+
+// execProgrammaticMigration checks if a programmatic migration exists for the
+// passed migration and proceeds to execute if one exists. If the programmatic
+// migration fails, the function will reset the database version to the version
+// it was set to before attempting to execute the programmatic migration.
+func (m *Migrate) execProgrammaticMigration(migr *Migration) error {
+	m.logVerbosePrintf("Running programmatic migration for %v\n",
+		migr.LogString())
+
+	programmaticMigration, ok := m.opts.programmaticMigrations[migr.Version]
+	if !ok {
+		return fmt.Errorf("no programmatic migration set for %v",
+			migr.LogString())
+	}
+
+	// Get the current database version before executing the programmatic migration.
+	curVersion, dirty, err := m.databaseDrv.Version()
+	if err != nil {
+		return fmt.Errorf("unable to get current version: %w", err)
+	}
+
+	if dirty {
+		return ErrDirty{curVersion}
+	}
+
+	// Persist that we are at the migration version of the programmatic
+	// migration.
+	if err = m.databaseDrv.SetVersion(int(migr.Version), true); err != nil {
+		return err
+	}
+
+	err = programmaticMigration(migr, m.databaseDrv)
+	if err != nil {
+		// Reset the version to the version set before executing the
+		// programmatic migration. Therefore, the programmatic migration
+		// will be re-executed on the next startup until it succeeds.
+		setErr := m.databaseDrv.SetVersion(curVersion, false)
+		if setErr != nil {
+			// Note that if we error here, the database version will
+			// remain in a dirty state. As we cannot know if the
+			// programmatic migration was executed or not in that
+			// scenario, manual intervention is required.
+			return fmt.Errorf("WARNING, failed to set migration "+
+				"version after programmatic migration "+
+				"errored. Manual intervention needed! "+
+				"Programmatic migration error: %w, version "+
+				"setting error : %w", err, setErr)
+		}
+
+		return fmt.Errorf("failed to execute programmatic migration: "+
+			"%w", err)
+	}
+
+	m.logVerbosePrintf("Programmatic migration finished for %v\n",
+		migr.LogString())
+
 	return nil
 }
 

--- a/migrate.go
+++ b/migrate.go
@@ -55,58 +55,60 @@ func (e ErrDirty) Error() string {
 	return fmt.Sprintf("Dirty database version %v. Fix and force version.", e.Version)
 }
 
-// PostStepCallback is a callback function type that can be used to execute a
-// Golang based migration step after a SQL based migration step has been
+// ProgrammaticMigration is a callback function type that can be used to execute
+// a Golang based migration step after a SQL based migration step has been
 // executed. The callback function receives the migration and the database
 // driver as arguments.
-type PostStepCallback func(migr *Migration, driver database.Driver) error
+type ProgrammaticMigration func(migr *Migration, driver database.Driver) error
 
 // options is a set of optional options that can be set when a Migrate instance
 // is created.
 type options struct {
-	// postStepCallbacks is a map of PostStepCallback functions that can be
-	// used to execute a Golang based migration step after a SQL based
-	// migration step has been executed. The key is the migration version
-	// and the value is the callback function that should be run _after_ the
-	// step was executed (but within the same database transaction).
-	postStepCallbacks map[uint]PostStepCallback
+	// programmaticMigrations is a map of ProgrammaticMigration functions
+	// that can be used to execute a Golang based migration step after a SQL
+	// based migration step has been executed. The key is the migration
+	// version and the value is the callback function that should be run
+	// _after_ the step was executed (but within the same database
+	// transaction).
+	programmaticMigrations map[uint]ProgrammaticMigration
 }
 
 // defaultOptions returns a new options struct with default values.
 func defaultOptions() options {
 	return options{
-		postStepCallbacks: make(map[uint]PostStepCallback),
+		programmaticMigrations: make(map[uint]ProgrammaticMigration),
 	}
 }
 
 // Option is a function that can be used to set options on a Migrate instance.
 type Option func(*options)
 
-// WithPostStepCallbacks is an option that can be used to set a map of
-// PostStepCallback functions that can be used to execute a Golang based
+// WithProgrammaticMigrations is an option that can be used to set a map of
+// ProgrammaticMigration functions that can be used to execute a Golang based
 // migration step after a SQL based migration step has been executed. The key is
-// the migration version and the value is the callback function that should be
-// run _after_ the step was executed (but before the version is marked as
-// cleanly executed). An error returned from the callback will cause the
-// migration to fail and the step to be marked as dirty.
-func WithPostStepCallbacks(
-	postStepCallbacks map[uint]PostStepCallback) Option {
-
+// the migration version and the value is the programmatic migration function
+// that should be run _after_ the step was executed (but before the version is
+// marked as cleanly executed). An error returned from the programmatic
+// migration will cause the migration to fail and the step to be marked as
+// dirty.
+func WithProgrammaticMigrations(pMigrs map[uint]ProgrammaticMigration) Option {
 	return func(o *options) {
-		o.postStepCallbacks = postStepCallbacks
+		o.programmaticMigrations = pMigrs
 	}
 }
 
-// WithPostStepCallback is an option that can be used to set a PostStepCallback
-// function that can be used to execute a Golang based migration step after the
-// SQL based migration step with the given version number has been executed. The
-// callback is the function that should be run _after_ the step was executed
-// (but before the version is marked as cleanly executed). An error returned
-// from the callback will cause the migration to fail and the step to be marked
-// as dirty.
-func WithPostStepCallback(version uint, callback PostStepCallback) Option {
+// WithProgrammaticMigration is an option that can be used to set a
+// ProgrammaticMigration function that can be used to execute a Golang based
+// migration step after the SQL based migration step with the given version
+// number has been executed. The programmatic migration is the function that
+// should be run _after_ the step was executed (but before the version is marked
+// as cleanly executed). An error returned from the programmatic migration will
+// cause the migration to fail and the step to be marked as dirty.
+func WithProgrammaticMigration(version uint,
+	pMigr ProgrammaticMigration) Option {
+
 	return func(o *options) {
-		o.postStepCallbacks[version] = callback
+		o.programmaticMigrations[version] = pMigr
 	}
 }
 
@@ -818,23 +820,26 @@ func (m *Migrate) runMigrations(ret <-chan interface{}) error {
 					return err
 				}
 
-				// If there is a post execution function for
-				// this migration, run it now.
-				cb, ok := m.opts.postStepCallbacks[migr.Version]
+				migrVer := migr.Version
+
+				// If there is a programmatic migration function
+				// for this migration, run it now.
+				cb, ok := m.opts.programmaticMigrations[migrVer]
 				if ok {
-					m.logVerbosePrintf("Running post step "+
-						"callback for %v\n", migr.LogString())
+					m.logVerbosePrintf("Running "+
+						"programmatic migration for "+
+						"%v\n", migr.LogString())
 
 					err := cb(migr, m.databaseDrv)
 					if err != nil {
 						return fmt.Errorf("failed to "+
-							"execute post "+
-							"step callback: %w",
-							err)
+							"execute programmatic "+
+							"migration: %w", err)
 					}
 
-					m.logVerbosePrintf("Post step callback "+
-						"finished for %v\n", migr.LogString())
+					m.logVerbosePrintf("Programmatic"+
+						"migration finished for "+
+						"%v\n", migr.LogString())
 				}
 			}
 

--- a/migrate.go
+++ b/migrate.go
@@ -55,63 +55,6 @@ func (e ErrDirty) Error() string {
 	return fmt.Sprintf("Dirty database version %v. Fix and force version.", e.Version)
 }
 
-// ProgrammaticMigration is a callback function type that can be used to execute
-// a Golang based migration step after a SQL based migration step has been
-// executed. The callback function receives the migration and the database
-// driver as arguments.
-type ProgrammaticMigration func(migr *Migration, driver database.Driver) error
-
-// options is a set of optional options that can be set when a Migrate instance
-// is created.
-type options struct {
-	// programmaticMigrations is a map of ProgrammaticMigration functions
-	// that can be used to execute a Golang based migration step after a SQL
-	// based migration step has been executed. The key is the migration
-	// version and the value is the callback function that should be run
-	// _after_ the step was executed (but within the same database
-	// transaction).
-	programmaticMigrations map[uint]ProgrammaticMigration
-}
-
-// defaultOptions returns a new options struct with default values.
-func defaultOptions() options {
-	return options{
-		programmaticMigrations: make(map[uint]ProgrammaticMigration),
-	}
-}
-
-// Option is a function that can be used to set options on a Migrate instance.
-type Option func(*options)
-
-// WithProgrammaticMigrations is an option that can be used to set a map of
-// ProgrammaticMigration functions that can be used to execute a Golang based
-// migration step after a SQL based migration step has been executed. The key is
-// the migration version and the value is the programmatic migration function
-// that should be run _after_ the step was executed (but before the version is
-// marked as cleanly executed). An error returned from the programmatic
-// migration will cause the migration to fail and the step to be marked as
-// dirty.
-func WithProgrammaticMigrations(pMigrs map[uint]ProgrammaticMigration) Option {
-	return func(o *options) {
-		o.programmaticMigrations = pMigrs
-	}
-}
-
-// WithProgrammaticMigration is an option that can be used to set a
-// ProgrammaticMigration function that can be used to execute a Golang based
-// migration step after the SQL based migration step with the given version
-// number has been executed. The programmatic migration is the function that
-// should be run _after_ the step was executed (but before the version is marked
-// as cleanly executed). An error returned from the programmatic migration will
-// cause the migration to fail and the step to be marked as dirty.
-func WithProgrammaticMigration(version uint,
-	pMigr ProgrammaticMigration) Option {
-
-	return func(o *options) {
-		o.programmaticMigrations[version] = pMigr
-	}
-}
-
 type Migrate struct {
 	sourceName   string
 	sourceDrv    source.Driver

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -23,6 +23,15 @@ import (
 //	| u d |  -  | u   | u d |   d |  -  | u d |
 var sourceStubMigrations *source.Migrations
 
+// sourceProgrammaticMigrations hold the following migrations:
+// u = up migration, d = down migration, n = version, SQL = SQL migration,
+// PGM = Programmatic migration
+//
+//	|  1  |  2  |  3  |  4  |  5  |  -  |  7  |
+//	| SQL | PGM | SQL | SQL | SQL |  -  | PGM |
+//	| u d | u d | u   | u d |   d |  -  | u   |
+var sourceProgrammaticMigrations *source.Migrations
+
 const (
 	srcDrvNameStub = "stub"
 	dbDrvNameStub  = "stub"
@@ -38,6 +47,20 @@ func init() {
 	sourceStubMigrations.Append(&source.Migration{Version: 5, Direction: source.Down, Identifier: "DROP 5"})
 	sourceStubMigrations.Append(&source.Migration{Version: 7, Direction: source.Up, Identifier: "CREATE 7"})
 	sourceStubMigrations.Append(&source.Migration{Version: 7, Direction: source.Down, Identifier: "DROP 7"})
+
+	// Init the sourceProgrammaticMigrations. Note that the content of the
+	// programmatic migrations for version 2 & 7 is defined in the
+	// respective unit tests where the sourceProgrammaticMigrations is used.
+	sourceProgrammaticMigrations = source.NewMigrations()
+	sourceProgrammaticMigrations.Append(&source.Migration{Version: 1, Direction: source.Up, Identifier: "CREATE 1"})
+	sourceProgrammaticMigrations.Append(&source.Migration{Version: 1, Direction: source.Down, Identifier: "DROP 1"})
+	sourceProgrammaticMigrations.Append(&source.Migration{Version: 2, Direction: source.Up, Identifier: ""})
+	sourceProgrammaticMigrations.Append(&source.Migration{Version: 2, Direction: source.Down, Identifier: ""})
+	sourceProgrammaticMigrations.Append(&source.Migration{Version: 3, Direction: source.Up, Identifier: "CREATE 3"})
+	sourceProgrammaticMigrations.Append(&source.Migration{Version: 4, Direction: source.Up, Identifier: "CREATE 4"})
+	sourceProgrammaticMigrations.Append(&source.Migration{Version: 4, Direction: source.Down, Identifier: "DROP 4"})
+	sourceProgrammaticMigrations.Append(&source.Migration{Version: 5, Direction: source.Down, Identifier: "DROP 5"})
+	sourceProgrammaticMigrations.Append(&source.Migration{Version: 7, Direction: source.Up, Identifier: ""})
 }
 
 type DummyInstance struct{ Name string }
@@ -882,9 +905,9 @@ func TestUpAndDown(t *testing.T) {
 func TestProgrammaticMigration(t *testing.T) {
 	m, _ := New("stub://", "stub://", WithProgrammaticMigrations(
 		map[uint]ProgrammaticMigration{
-			1: func(m *Migration, driver database.Driver) error {
+			2: func(m *Migration, driver database.Driver) error {
 				return driver.Run(
-					strings.NewReader("CALLBACK 1"),
+					strings.NewReader("CALLBACK 2"),
 				)
 			},
 			7: func(m *Migration, driver database.Driver) error {
@@ -894,7 +917,7 @@ func TestProgrammaticMigration(t *testing.T) {
 			},
 		},
 	))
-	m.sourceDrv.(*sStub.Stub).Migrations = sourceStubMigrations
+	m.sourceDrv.(*sStub.Stub).Migrations = sourceProgrammaticMigrations
 	dbDrv := m.databaseDrv.(*dStub.Stub)
 
 	// go Up first
@@ -903,10 +926,9 @@ func TestProgrammaticMigration(t *testing.T) {
 	}
 	expectedSequence := migrationSequence{
 		mr("CREATE 1"),
-		mr("CALLBACK 1"),
+		mr("CALLBACK 2"),
 		mr("CREATE 3"),
 		mr("CREATE 4"),
-		mr("CREATE 7"),
 		mr("CALLBACK 7"),
 	}
 	equalDbSeq(t, 0, expectedSequence, dbDrv)
@@ -920,24 +942,25 @@ func TestProgrammaticMigration(t *testing.T) {
 	if err := m.Down(); err != nil {
 		t.Fatal(err)
 	}
+
+	// Note that "CALLBACK 7" isn't repeated when going down, as that
+	// migration source only contains an .up migration for version 7, and
+	// not a .down migration.
 	expectedSequence = migrationSequence{
 		mr("CREATE 1"),
-		mr("CALLBACK 1"),
+		mr("CALLBACK 2"),
 		mr("CREATE 3"),
 		mr("CREATE 4"),
-		mr("CREATE 7"),
-		mr("CALLBACK 7"),
-		mr("DROP 7"),
 		mr("CALLBACK 7"),
 		mr("DROP 5"),
 		mr("DROP 4"),
+		mr("CALLBACK 2"),
 		mr("DROP 1"),
-		mr("CALLBACK 1"),
 	}
 	equalDbSeq(t, 1, expectedSequence, dbDrv)
 
-	if !bytes.Equal(dbDrv.LastRunMigration, []byte("CALLBACK 1")) {
-		t.Fatalf("expected database last migration to be callback 1, "+
+	if !bytes.Equal(dbDrv.LastRunMigration, []byte("DROP 1")) {
+		t.Fatalf("expected database last migration to be DROP 1, "+
 			"got %s", dbDrv.LastRunMigration)
 	}
 
@@ -947,19 +970,15 @@ func TestProgrammaticMigration(t *testing.T) {
 	}
 	expectedSequence = migrationSequence{
 		mr("CREATE 1"),
-		mr("CALLBACK 1"),
+		mr("CALLBACK 2"),
 		mr("CREATE 3"),
 		mr("CREATE 4"),
-		mr("CREATE 7"),
-		mr("CALLBACK 7"),
-		mr("DROP 7"),
 		mr("CALLBACK 7"),
 		mr("DROP 5"),
 		mr("DROP 4"),
+		mr("CALLBACK 2"),
 		mr("DROP 1"),
-		mr("CALLBACK 1"),
 		mr("CREATE 1"),
-		mr("CALLBACK 1"),
 	}
 	equalDbSeq(t, 2, expectedSequence, dbDrv)
 
@@ -968,25 +987,403 @@ func TestProgrammaticMigration(t *testing.T) {
 	}
 	expectedSequence = migrationSequence{
 		mr("CREATE 1"),
-		mr("CALLBACK 1"),
+		mr("CALLBACK 2"),
 		mr("CREATE 3"),
 		mr("CREATE 4"),
-		mr("CREATE 7"),
-		mr("CALLBACK 7"),
-		mr("DROP 7"),
 		mr("CALLBACK 7"),
 		mr("DROP 5"),
 		mr("DROP 4"),
+		mr("CALLBACK 2"),
 		mr("DROP 1"),
-		mr("CALLBACK 1"),
 		mr("CREATE 1"),
-		mr("CALLBACK 1"),
+		mr("CALLBACK 2"),
 		mr("CREATE 3"),
 		mr("CREATE 4"),
-		mr("CREATE 7"),
 		mr("CALLBACK 7"),
 	}
 	equalDbSeq(t, 3, expectedSequence, dbDrv)
+}
+
+// TestProgrammaticMigrationError simulates a programmatic migration that fails,
+// and ensures that:
+//  1. The migration process stops and returns the programmatic migration error.
+//  2. The migration version is set to the migration version set prior to
+//     executing the programmatic migration if it errors.
+//  3. Re-running Up will re-attempt the programmatic migration.
+//  4. Down will not re-execute a programmatic migration if it errored, as the
+//     version should have been set to the version prior to executing the
+//     programmatic migration.
+//  5. Once the programmatic migration succeeds, the migration can finalize and
+//     reach the latest version cleanly.
+//  6. Down will only execute the programmatic migration at a given version if a
+//     ".down" file is defined for the programmatic migration.
+func TestProgrammaticMigrationError(t *testing.T) {
+	var (
+		cbError    = errors.New("programmatic migration failure")
+		shouldFail = true
+	)
+
+	// The programmatic migration for version 2 will error if
+	// shouldFail == false, and succeed if it is set to true.
+	m, _ := New("stub://", "stub://", WithProgrammaticMigrations(
+		map[uint]ProgrammaticMigration{
+			2: func(migr *Migration, driver database.Driver) error {
+				if shouldFail {
+					err := driver.Run(strings.NewReader(
+						"CALLBACK 2 FAILURE",
+					))
+					if err != nil {
+						return err
+					}
+
+					return cbError
+				}
+
+				err := driver.Run(strings.NewReader(
+					"CALLBACK 2 SUCCESS",
+				))
+				if err != nil {
+					return err
+				}
+
+				return nil
+			},
+			7: func(m *Migration, driver database.Driver) error {
+				return driver.Run(
+					strings.NewReader("CALLBACK 7"),
+				)
+			},
+		},
+	))
+
+	m.sourceDrv.(*sStub.Stub).Migrations = sourceProgrammaticMigrations
+	dbDrv := m.databaseDrv.(*dStub.Stub)
+
+	// 1) Run Up — the programmatic migration for 2 should fail.
+	err := m.Up()
+	if !errors.Is(err, cbError) {
+		t.Fatal("expected cbError from failing programmatic migration")
+	}
+
+	// The sequence should show the migrations prior to version 2, and then
+	// the failing callback for version 2.
+	expectedSequence := migrationSequence{
+		mr("CREATE 1"),
+		mr("CALLBACK 2 FAILURE"),
+	}
+	equalDbSeq(t, 0, expectedSequence, dbDrv)
+
+	if !bytes.Equal(dbDrv.LastRunMigration, []byte("CALLBACK 2 FAILURE")) {
+		t.Fatalf("expected database last migration to be callback 2, "+
+			"got %s", dbDrv.LastRunMigration)
+	}
+
+	// 2) Due to that the programmatic migration errored, the version should
+	// have been reset to the version set before the programmatic migration
+	// was executed.
+	checkVersion(t, dbDrv, 1)
+
+	// 3) Re-run Up — since the database version is set to version 1, it
+	// should try the programmatic migration again at version 2 and fail
+	// again.
+	err = m.Up()
+	if !errors.Is(err, cbError) {
+		t.Fatal("expected cbError from failing programmatic migration")
+	}
+
+	// The programmatic migration for version 2 should now have failed twice.
+	expectedSequence = migrationSequence{
+		mr("CREATE 1"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("CALLBACK 2 FAILURE"),
+	}
+	equalDbSeq(t, 0, expectedSequence, dbDrv)
+
+	if !bytes.Equal(dbDrv.LastRunMigration, []byte("CALLBACK 2 FAILURE")) {
+		t.Fatalf("expected database last migration to be callback 2, "+
+			"got %s", dbDrv.LastRunMigration)
+	}
+
+	// The version should have been reset to 1 once again.
+	checkVersion(t, dbDrv, 1)
+
+	// 4) Execute down — as the version should have been reset to 1, this
+	// should not re-execute the programmatic migration for version 2.
+	err = m.Down()
+	if err != nil {
+		t.Fatalf("unexpected Down error: %v", err)
+	}
+
+	expectedSequence = migrationSequence{
+		mr("CREATE 1"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("DROP 1"),
+	}
+	equalDbSeq(t, 0, expectedSequence, dbDrv)
+
+	if !bytes.Equal(dbDrv.LastRunMigration, []byte("DROP 1")) {
+		t.Fatalf("expected database last migration to be DROP 1, "+
+			"got %s", dbDrv.LastRunMigration)
+	}
+
+	// The version should now be at -1, as the migration for version 1 has
+	// been dropped.
+	checkVersion(t, dbDrv, -1)
+
+	// 5) Make the callback succeed by setting shouldFail to false and run
+	// again. It should now successfully re-run the callback and then
+	// finalize the migration cleanly to the latest version (7).
+	shouldFail = false
+
+	err = m.Up()
+	if err != nil {
+		t.Fatalf("unexpected Up error: %v", err)
+	}
+
+	expectedSequence = migrationSequence{
+		mr("CREATE 1"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("DROP 1"),
+		mr("CREATE 1"),
+		mr("CALLBACK 2 SUCCESS"),
+		mr("CREATE 3"),
+		mr("CREATE 4"),
+		mr("CALLBACK 7"),
+	}
+	equalDbSeq(t, 0, expectedSequence, dbDrv)
+
+	// And the last run migration should be from the callback.
+	if !bytes.Equal(dbDrv.LastRunMigration, []byte("CALLBACK 7")) {
+		t.Fatalf("expected last run migration to be from the "+
+			"programmatic migration, got %q",
+			dbDrv.LastRunMigration)
+	}
+
+	// The version should now be the latest migration version 7 and not
+	// dirty.
+	checkVersion(t, dbDrv, 7)
+
+	// Try Up again — it should be a no-op since we are at the latest
+	// version, and shouldn't run the programmatic migration again.
+	err = m.Up()
+	if !errors.Is(err, ErrNoChange) {
+		t.Fatalf("unexpected error after programmatic migration "+
+			"succeed: %v", err)
+	}
+
+	// Ensure the callback wasn't re-run.
+	expectedSequence = migrationSequence{
+		mr("CREATE 1"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("DROP 1"),
+		mr("CREATE 1"),
+		mr("CALLBACK 2 SUCCESS"),
+		mr("CREATE 3"),
+		mr("CREATE 4"),
+		mr("CALLBACK 7"),
+	}
+	equalDbSeq(t, 0, expectedSequence, dbDrv)
+
+	// And the last run migration should be from the previous callback.
+	if !bytes.Equal(dbDrv.LastRunMigration, []byte("CALLBACK 7")) {
+		t.Fatalf("expected last run migration to be from programmatic"+
+			"migration, got %q", dbDrv.LastRunMigration)
+	}
+
+	checkVersion(t, dbDrv, 7)
+
+	// 6) Finally, running Down now should only execute the programmatic
+	// migration at for version 2, as that programmatic migration is the
+	// only programmatic migration that has a defined ".down" file.
+	// We start setting the shouldFail boolean to true again, be able to
+	// test the retry logic for .down migrations for programmatic migrations
+	// as well.
+	shouldFail = true
+
+	err = m.Down()
+	if !errors.Is(err, cbError) {
+		t.Fatal("expected cbError from failing programmatic migration")
+	}
+
+	expectedSequence = migrationSequence{
+		mr("CREATE 1"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("DROP 1"),
+		mr("CREATE 1"),
+		mr("CALLBACK 2 SUCCESS"),
+		mr("CREATE 3"),
+		mr("CREATE 4"),
+		mr("CALLBACK 7"),
+		mr("DROP 5"),
+		mr("DROP 4"),
+		mr("CALLBACK 2 FAILURE"),
+	}
+	equalDbSeq(t, 0, expectedSequence, dbDrv)
+
+	if !bytes.Equal(dbDrv.LastRunMigration, []byte("CALLBACK 2 FAILURE")) {
+		t.Fatalf("expected database last migration to be callback 2, "+
+			"got %s", dbDrv.LastRunMigration)
+	}
+
+	// The version should be at 2, as the programmatic migration for that
+	// version should have failed.
+	checkVersion(t, dbDrv, 2)
+
+	// Finally, we set shouldFail to false again, and retry the downgrade.
+	// This should now succeed and execute the programmatic migration for
+	// version 2 successfully.
+	shouldFail = false
+
+	err = m.Down()
+	if err != nil {
+		t.Fatalf("unexpected down error: %v", err)
+	}
+
+	expectedSequence = migrationSequence{
+		mr("CREATE 1"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("DROP 1"),
+		mr("CREATE 1"),
+		mr("CALLBACK 2 SUCCESS"),
+		mr("CREATE 3"),
+		mr("CREATE 4"),
+		mr("CALLBACK 7"),
+		mr("DROP 5"),
+		mr("DROP 4"),
+		mr("CALLBACK 2 FAILURE"),
+		mr("CALLBACK 2 SUCCESS"),
+		mr("DROP 1"),
+	}
+	equalDbSeq(t, 0, expectedSequence, dbDrv)
+
+	if !bytes.Equal(dbDrv.LastRunMigration, []byte("DROP 1")) {
+		t.Fatalf("expected database last migration to be DROP 1, "+
+			"got %s", dbDrv.LastRunMigration)
+	}
+
+	// The version should now be at -1, as the migration for version 1 has
+	// been dropped.
+	checkVersion(t, dbDrv, -1)
+}
+
+// TestMigrationTypeCombos test ensures that a migration cannot be both an SQL
+// migration and a programmatic migration at the same time. It also tests that a
+// migration can be neither an SQL migration nor a programmatic migration.
+func TestMigrationTypeCombos(t *testing.T) {
+	// Test that a migration can't be both an SQL migration and a
+	// programmatic migration at the same time.
+	m1, _ := New("stub://", "stub://", WithProgrammaticMigrations(
+		map[uint]ProgrammaticMigration{
+			2: func(m *Migration, driver database.Driver) error {
+				return driver.Run(
+					strings.NewReader("CALLBACK 2"),
+				)
+			},
+		},
+	))
+	dbDrv1 := m1.databaseDrv.(*dStub.Stub)
+
+	bothTypeMig := source.NewMigrations()
+	bothTypeMig.Append(
+		&source.Migration{Version: 1, Direction: source.Up,
+			Identifier: "CREATE 1"},
+	)
+	bothTypeMig.Append(
+		&source.Migration{Version: 1, Direction: source.Down,
+			Identifier: "DROP 1"},
+	)
+	bothTypeMig.Append(
+		&source.Migration{Version: 2, Direction: source.Up,
+			Identifier: "CREATE 2"},
+	)
+	bothTypeMig.Append(
+		&source.Migration{Version: 2, Direction: source.Down,
+			Identifier: "DROP 2"},
+	)
+
+	m1.sourceDrv.(*sStub.Stub).Migrations = bothTypeMig
+
+	err := m1.Up()
+	if err == nil || !errors.Is(err, ErrMixedMigration) {
+		t.Fatalf("expected %v, but got %v", ErrMixedMigration, err)
+	}
+
+	// We expect that only migration 1 should have been executed, as the
+	// migration for version 2 should have errored before being executed.
+	expectedSequence := migrationSequence{
+		mr("CREATE 1"),
+	}
+	equalDbSeq(t, 0, expectedSequence, dbDrv1)
+
+	// The db version should only be at 1, as the migration for version 2
+	// should have errored before any version was set.
+	checkVersion(t, dbDrv1, 1)
+
+	err = m1.Down()
+	if err != nil {
+		t.Fatalf("expected %v, but got %v", ErrMixedMigration, err)
+	}
+
+	// As the up migration for version 2 was never run, we expect that we
+	// only execute the down migration for version 1 as well.
+	expectedSequence = migrationSequence{
+		mr("CREATE 1"),
+		mr("DROP 1"),
+	}
+	equalDbSeq(t, 0, expectedSequence, dbDrv1)
+
+	checkVersion(t, dbDrv1, -1)
+
+	// Test that a migration can be neither an SQL migration nor a
+	// programmatic migration.
+	m2, _ := New("stub://", "stub://")
+	dbDrv2 := m2.databaseDrv.(*dStub.Stub)
+
+	noTypeMig := source.NewMigrations()
+	noTypeMig.Append(
+		&source.Migration{Version: 1, Direction: source.Up,
+			Identifier: ""},
+	)
+	noTypeMig.Append(
+		&source.Migration{Version: 1, Direction: source.Down,
+			Identifier: ""},
+	)
+
+	m2.sourceDrv.(*sStub.Stub).Migrations = noTypeMig
+
+	err = m2.Up()
+	if err != nil {
+		t.Fatal("unexpected error when a migration was neither an " +
+			"SQL migration nor a programmatic migration")
+	}
+
+	// We expect that no migration sequence has been executed, as the
+	// migration for version 1 didn't contain any SQL or programmatic
+	// migration.
+	equalDbSeq(t, 0, migrationSequence{}, dbDrv2)
+
+	// The version should have been changed to 1 though, as the migration
+	// should be seen as a valid migration.
+	checkVersion(t, dbDrv2, 1)
+
+	// The same behavior should be observed when downgrading.
+	err = m2.Down()
+	if err != nil {
+		t.Fatal("unexpected error when a migration was neither an " +
+			"SQL migration nor a programmatic migration")
+	}
+
+	// We still expect no migration sequence.
+	equalDbSeq(t, 0, migrationSequence{}, dbDrv2)
+
+	// The version should have been changed to -1 though, as the migration
+	// should be seen as a valid migration.
+	checkVersion(t, dbDrv2, -1)
 }
 
 func TestUpDirty(t *testing.T) {
@@ -1523,5 +1920,21 @@ func equalDbSeq(t *testing.T, i int, expected migrationSequence, got *dStub.Stub
 	bs := expected.bodySequence()
 	if !got.EqualSequence(bs) {
 		t.Fatalf("\nexpected sequence %v,\ngot               %v, in %v", bs, got.MigrationSequence, i)
+	}
+}
+
+// checkVersion is a helper function to check the migration version and dirty
+// state.
+func checkVersion(t *testing.T, dbDrv *dStub.Stub, expVer int) {
+	v, dirty, err := dbDrv.Version()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v != expVer {
+		t.Fatalf("expected version %d, got v=%d", expVer, v)
+	}
+	if dirty {
+		t.Fatalf("expected clean version, but was dirty")
 	}
 }

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -904,16 +904,26 @@ func TestUpAndDown(t *testing.T) {
 
 func TestProgrammaticMigration(t *testing.T) {
 	m, _ := New("stub://", "stub://", WithProgrammaticMigrations(
-		map[uint]ProgrammaticMigration{
-			2: func(m *Migration, driver database.Driver) error {
-				return driver.Run(
-					strings.NewReader("CALLBACK 2"),
-				)
+		map[uint]ProgrammaticMigrEntry{
+			2: {
+				ResetVersionOnError: true,
+				ProgrammaticMigr: func(m *Migration,
+					driver database.Driver) error {
+
+					return driver.Run(
+						strings.NewReader("CALLBACK 2"),
+					)
+				},
 			},
-			7: func(m *Migration, driver database.Driver) error {
-				return driver.Run(
-					strings.NewReader("CALLBACK 7"),
-				)
+			7: {
+				ResetVersionOnError: true,
+				ProgrammaticMigr: func(m *Migration,
+					driver database.Driver) error {
+
+					return driver.Run(
+						strings.NewReader("CALLBACK 7"),
+					)
+				},
 			},
 		},
 	))
@@ -1026,32 +1036,43 @@ func TestProgrammaticMigrationError(t *testing.T) {
 	// The programmatic migration for version 2 will error if
 	// shouldFail == false, and succeed if it is set to true.
 	m, _ := New("stub://", "stub://", WithProgrammaticMigrations(
-		map[uint]ProgrammaticMigration{
-			2: func(migr *Migration, driver database.Driver) error {
-				if shouldFail {
+		map[uint]ProgrammaticMigrEntry{
+			2: {
+				ResetVersionOnError: true,
+				ProgrammaticMigr: func(migr *Migration,
+					driver database.Driver) error {
+
+					if shouldFail {
+						err := driver.Run(
+							strings.NewReader(
+								"CALLBACK 2 FAILURE",
+							))
+						if err != nil {
+							return err
+						}
+
+						return cbError
+					}
+
 					err := driver.Run(strings.NewReader(
-						"CALLBACK 2 FAILURE",
+						"CALLBACK 2 SUCCESS",
 					))
 					if err != nil {
 						return err
 					}
 
-					return cbError
-				}
-
-				err := driver.Run(strings.NewReader(
-					"CALLBACK 2 SUCCESS",
-				))
-				if err != nil {
-					return err
-				}
-
-				return nil
+					return nil
+				},
 			},
-			7: func(m *Migration, driver database.Driver) error {
-				return driver.Run(
-					strings.NewReader("CALLBACK 7"),
-				)
+			7: {
+				ResetVersionOnError: true,
+				ProgrammaticMigr: func(m *Migration,
+					driver database.Driver) error {
+
+					return driver.Run(
+						strings.NewReader("CALLBACK 7"),
+					)
+				},
 			},
 		},
 	))
@@ -1271,6 +1292,60 @@ func TestProgrammaticMigrationError(t *testing.T) {
 	checkVersion(t, dbDrv, -1)
 }
 
+// TestProgrammaticMigrationErrorNoRerun ensures that when ResetVersionOnError
+// is false, a failing programmatic migration leaves the database dirty at the
+// current migration version instead of rewinding to the prior version.
+func TestProgrammaticMigrationErrorNoRerun(t *testing.T) {
+	cbError := errors.New("programmatic migration failure")
+
+	m, _ := New("stub://", "stub://", WithProgrammaticMigrations(
+		map[uint]ProgrammaticMigrEntry{
+			2: {
+				ResetVersionOnError: false,
+				ProgrammaticMigr: func(migr *Migration,
+					driver database.Driver) error {
+
+					if err := driver.Run(strings.NewReader(
+						"CALLBACK 2 FAILURE",
+					)); err != nil {
+						return err
+					}
+					return cbError
+				},
+			},
+		},
+	))
+
+	m.sourceDrv.(*sStub.Stub).Migrations = sourceProgrammaticMigrations
+	dbDrv := m.databaseDrv.(*dStub.Stub)
+
+	err := m.Up()
+	if !errors.Is(err, cbError) {
+		t.Fatalf("expected cbError from failing programmatic "+
+			"migration, got %v", err)
+	}
+
+	version, dirty, err := dbDrv.Version()
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if version != 2 || !dirty {
+		t.Fatalf("expected version 2 dirty after failure, got "+
+			"version=%d dirty=%v", version, dirty)
+	}
+	if !bytes.Equal(dbDrv.LastRunMigration, []byte("CALLBACK 2 FAILURE")) {
+		t.Fatalf("expected last migration body to be failure "+
+			"callback, got %s", dbDrv.LastRunMigration)
+	}
+
+	// Re-running Up again, should fail with ErrDirty for version 2, as
+	// the database should be in a dirty state.
+	if err = m.Up(); !errors.Is(err, ErrDirty{2}) {
+		t.Fatalf("expected version 2 dirty error on re-running Up, "+
+			"got %v", err)
+	}
+}
+
 // TestMigrationTypeCombos test ensures that a migration cannot be both an SQL
 // migration and a programmatic migration at the same time. It also tests that a
 // migration can be neither an SQL migration nor a programmatic migration.
@@ -1278,11 +1353,16 @@ func TestMigrationTypeCombos(t *testing.T) {
 	// Test that a migration can't be both an SQL migration and a
 	// programmatic migration at the same time.
 	m1, _ := New("stub://", "stub://", WithProgrammaticMigrations(
-		map[uint]ProgrammaticMigration{
-			2: func(m *Migration, driver database.Driver) error {
-				return driver.Run(
-					strings.NewReader("CALLBACK 2"),
-				)
+		map[uint]ProgrammaticMigrEntry{
+			2: {
+				ResetVersionOnError: true,
+				ProgrammaticMigr: func(m *Migration,
+					driver database.Driver) error {
+
+					return driver.Run(
+						strings.NewReader("CALLBACK 2"),
+					)
+				},
 			},
 		},
 	))

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -879,9 +879,9 @@ func TestUpAndDown(t *testing.T) {
 	equalDbSeq(t, 1, expectedSequence, dbDrv)
 }
 
-func TestPostStepCallback(t *testing.T) {
-	m, _ := New("stub://", "stub://", WithPostStepCallbacks(
-		map[uint]PostStepCallback{
+func TestProgrammaticMigration(t *testing.T) {
+	m, _ := New("stub://", "stub://", WithProgrammaticMigrations(
+		map[uint]ProgrammaticMigration{
 			1: func(m *Migration, driver database.Driver) error {
 				return driver.Run(
 					strings.NewReader("CALLBACK 1"),

--- a/programmatic_migration.go
+++ b/programmatic_migration.go
@@ -2,21 +2,18 @@ package migrate
 
 import "github.com/golang-migrate/migrate/v4/database"
 
-// ProgrammaticMigration is a callback function type that can be used to execute
-// a Golang based migration step after a SQL based migration step has been
-// executed. The callback function receives the migration and the database
-// driver as arguments.
+// ProgrammaticMigration is a Golang function type that can be used to execute
+// a Golang-based migration. The Golang function receives the migration and
+// the database driver as arguments.
 type ProgrammaticMigration func(migr *Migration, driver database.Driver) error
 
-// options is a set of optional options that can be set when a Migrate instance
-// is created.
+// options is a set of optional parameters that can be set when creating a
+// Migrate instance.
 type options struct {
 	// programmaticMigrations is a map of ProgrammaticMigration functions
-	// that can be used to execute a Golang based migration step after a SQL
-	// based migration step has been executed. The key is the migration
-	// version and the value is the callback function that should be run
-	// _after_ the step was executed (but within the same database
-	// transaction).
+	// that can be used to execute a Golang-based migration. The key is the
+	// migration version, and the value is the Golang function that should
+	// be run.
 	programmaticMigrations map[uint]ProgrammaticMigration
 }
 
@@ -31,26 +28,30 @@ func defaultOptions() options {
 type Option func(*options)
 
 // WithProgrammaticMigrations is an option that can be used to set a map of
-// ProgrammaticMigration functions that can be used to execute a Golang based
-// migration step after a SQL based migration step has been executed. The key is
-// the migration version and the value is the programmatic migration function
-// that should be run _after_ the step was executed (but before the version is
-// marked as cleanly executed). An error returned from the programmatic
-// migration will cause the migration to fail and the step to be marked as
-// dirty.
+// ProgrammaticMigration functions that can be used to execute a Golang-based
+// migration step. The key is the migration version, and the value is the
+// Golang function that should be run. An error returned from the programmatic
+// migration will cause the migration to fail but will **not** set the database
+// to a dirty state. Additionally, if the programmatic migration fails, the
+// database version will be reset to the last set version before executing the
+// programmatic migration. The effect of this is that the programmatic migration
+// will be re-run on the next startup of the database.
 func WithProgrammaticMigrations(pMigrs map[uint]ProgrammaticMigration) Option {
 	return func(o *options) {
-		o.programmaticMigrations = pMigrs
+		for version, pMigr := range pMigrs {
+			WithProgrammaticMigration(version, pMigr)(o)
+		}
 	}
 }
 
 // WithProgrammaticMigration is an option that can be used to set a
 // ProgrammaticMigration function that can be used to execute a Golang based
-// migration step after the SQL based migration step with the given version
-// number has been executed. The programmatic migration is the function that
-// should be run _after_ the step was executed (but before the version is marked
-// as cleanly executed). An error returned from the programmatic migration will
-// cause the migration to fail and the step to be marked as dirty.
+// migration.  An error returned from the programmatic migration will cause the
+// migration to fail but will **not** set the database to a dirty state.
+// Additionally, if the programmatic migration fails, the database version will
+// be reset to the last set version before executing the programmatic migration.
+// The effect of this is that the programmatic migration will be re-run on the
+// next startup of the database.
 func WithProgrammaticMigration(version uint,
 	pMigr ProgrammaticMigration) Option {
 

--- a/programmatic_migration.go
+++ b/programmatic_migration.go
@@ -1,0 +1,60 @@
+package migrate
+
+import "github.com/golang-migrate/migrate/v4/database"
+
+// ProgrammaticMigration is a callback function type that can be used to execute
+// a Golang based migration step after a SQL based migration step has been
+// executed. The callback function receives the migration and the database
+// driver as arguments.
+type ProgrammaticMigration func(migr *Migration, driver database.Driver) error
+
+// options is a set of optional options that can be set when a Migrate instance
+// is created.
+type options struct {
+	// programmaticMigrations is a map of ProgrammaticMigration functions
+	// that can be used to execute a Golang based migration step after a SQL
+	// based migration step has been executed. The key is the migration
+	// version and the value is the callback function that should be run
+	// _after_ the step was executed (but within the same database
+	// transaction).
+	programmaticMigrations map[uint]ProgrammaticMigration
+}
+
+// defaultOptions returns a new options struct with default values.
+func defaultOptions() options {
+	return options{
+		programmaticMigrations: make(map[uint]ProgrammaticMigration),
+	}
+}
+
+// Option is a function that can be used to set options on a Migrate instance.
+type Option func(*options)
+
+// WithProgrammaticMigrations is an option that can be used to set a map of
+// ProgrammaticMigration functions that can be used to execute a Golang based
+// migration step after a SQL based migration step has been executed. The key is
+// the migration version and the value is the programmatic migration function
+// that should be run _after_ the step was executed (but before the version is
+// marked as cleanly executed). An error returned from the programmatic
+// migration will cause the migration to fail and the step to be marked as
+// dirty.
+func WithProgrammaticMigrations(pMigrs map[uint]ProgrammaticMigration) Option {
+	return func(o *options) {
+		o.programmaticMigrations = pMigrs
+	}
+}
+
+// WithProgrammaticMigration is an option that can be used to set a
+// ProgrammaticMigration function that can be used to execute a Golang based
+// migration step after the SQL based migration step with the given version
+// number has been executed. The programmatic migration is the function that
+// should be run _after_ the step was executed (but before the version is marked
+// as cleanly executed). An error returned from the programmatic migration will
+// cause the migration to fail and the step to be marked as dirty.
+func WithProgrammaticMigration(version uint,
+	pMigr ProgrammaticMigration) Option {
+
+	return func(o *options) {
+		o.programmaticMigrations[version] = pMigr
+	}
+}

--- a/programmatic_migration.go
+++ b/programmatic_migration.go
@@ -7,20 +7,39 @@ import "github.com/golang-migrate/migrate/v4/database"
 // the database driver as arguments.
 type ProgrammaticMigration func(migr *Migration, driver database.Driver) error
 
+// ProgrammaticMigrEntry configures how a programmatic migration should run.
+type ProgrammaticMigrEntry struct {
+	// ResetVersionOnError determines the behavior if the programmatic
+	// migration errors. If set to `true` the migration logic will reset the
+	// database to the prior version, so the migration is retried on the
+	// next startup.
+	// If set to `false`, the database will be left in dirty state at the
+	// migration version of the programmatic migration.
+	//
+	// NOTE: If this is set to true, the ProgrammaticMigration's
+	// implementation should account for the fact that it may be re-executed
+	// on the next startup if it errors. This could, for example, be done by
+	// executing the entire migration within a single database transaction,
+	// which is not committed if an error occurs.
+	ResetVersionOnError bool
+
+	// ProgrammaticMigr is the holds the Golang-based migration function.
+	ProgrammaticMigr ProgrammaticMigration
+}
+
 // options is a set of optional parameters that can be set when creating a
 // Migrate instance.
 type options struct {
-	// programmaticMigrations is a map of ProgrammaticMigration functions
+	// programmaticMigrations is a map of ProgrammaticMigrEntry objects
 	// that can be used to execute a Golang-based migration. The key is the
-	// migration version, and the value is the Golang function that should
-	// be run.
-	programmaticMigrations map[uint]ProgrammaticMigration
+	// migration version, and the value is the ProgrammaticMigrEntry.
+	programmaticMigrations map[uint]ProgrammaticMigrEntry
 }
 
 // defaultOptions returns a new options struct with default values.
 func defaultOptions() options {
 	return options{
-		programmaticMigrations: make(map[uint]ProgrammaticMigration),
+		programmaticMigrations: make(map[uint]ProgrammaticMigrEntry),
 	}
 }
 
@@ -28,15 +47,19 @@ func defaultOptions() options {
 type Option func(*options)
 
 // WithProgrammaticMigrations is an option that can be used to set a map of
-// ProgrammaticMigration functions that can be used to execute a Golang-based
+// ProgrammaticMigrEntry objects that can be used to execute a Golang-based
 // migration step. The key is the migration version, and the value is the
-// Golang function that should be run. An error returned from the programmatic
-// migration will cause the migration to fail but will **not** set the database
+// ProgrammaticMigrEntry.
+// The ProgrammaticMigrEntry also defines the behavior if the Golang-based
+// migration errors:
+// * One option is that the migration fails but does **not** set the database
 // to a dirty state. Additionally, if the programmatic migration fails, the
 // database version will be reset to the last set version before executing the
 // programmatic migration. The effect of this is that the programmatic migration
 // will be re-run on the next startup of the database.
-func WithProgrammaticMigrations(pMigrs map[uint]ProgrammaticMigration) Option {
+// * The other alternative is that the database will be left in dirty state at
+// the migration version of the programmatic migration.
+func WithProgrammaticMigrations(pMigrs map[uint]ProgrammaticMigrEntry) Option {
 	return func(o *options) {
 		for version, pMigr := range pMigrs {
 			WithProgrammaticMigration(version, pMigr)(o)
@@ -45,15 +68,19 @@ func WithProgrammaticMigrations(pMigrs map[uint]ProgrammaticMigration) Option {
 }
 
 // WithProgrammaticMigration is an option that can be used to set a
-// ProgrammaticMigration function that can be used to execute a Golang based
-// migration.  An error returned from the programmatic migration will cause the
-// migration to fail but will **not** set the database to a dirty state.
-// Additionally, if the programmatic migration fails, the database version will
-// be reset to the last set version before executing the programmatic migration.
-// The effect of this is that the programmatic migration will be re-run on the
-// next startup of the database.
+// ProgrammaticMigration object that can be used to execute a Golang-based
+// migration.
+// The ProgrammaticMigrEntry also defines the behavior if the Golang-based
+// migration errors:
+// * One option is that the migration fails but does **not** set the database
+// to a dirty state. Additionally, if the programmatic migration fails, the
+// database version will be reset to the last set version before executing the
+// programmatic migration. The effect of this is that the programmatic migration
+// will be re-run on the next startup of the database.
+// * The other alternative is that the database will be left in dirty state at
+// the migration version of the programmatic migration.
 func WithProgrammaticMigration(version uint,
-	pMigr ProgrammaticMigration) Option {
+	pMigr ProgrammaticMigrEntry) Option {
 
 	return func(o *options) {
 		o.programmaticMigrations[version] = pMigr

--- a/util.go
+++ b/util.go
@@ -1,8 +1,12 @@
 package migrate
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	nurl "net/url"
+	"regexp"
 	"strings"
 )
 
@@ -58,4 +62,74 @@ func FilterCustomQuery(u *nurl.URL) *nurl.URL {
 	}
 	ux.RawQuery = vx.Encode()
 	return &ux
+}
+
+// hasSQLMigration checks if the passed data contains executable statements,
+// meaning that the data doesn't only contain comments/whitespace or semicolons.
+func hasSQLMigration(data string) (bool, error) {
+	// Remove Byte Order Mark (BOM) if present in the migration file.
+	data = strings.TrimPrefix(data, "\uFEFF")
+
+	// Strip block comments /* ... */ (non-greedy, across lines).
+	reBlock := regexp.MustCompile(`(?s)/\*.*?\*/`)
+	data = reBlock.ReplaceAllString(data, "")
+
+	// Strip line comments -- ... (to end of line).
+	reLine := regexp.MustCompile(`(?m)--[^\n\r]*`)
+	data = reLine.ReplaceAllString(data, "")
+
+	// Trim whitespaces.
+	data = strings.TrimSpace(data)
+
+	// Remove any semicolons, newlines, tabs, or spaces from the beginning
+	// and end of the string.
+	data = strings.Trim(data, ";\r\n\t ")
+
+	// If the string still contains any characters, the data likely
+	// contains executable statements.
+	return len(data) > 0, nil
+}
+
+// classifyMigrationBody peeks at a limited prefix of the migration to
+// determine if it contains SQL, while preserving the full body for later
+// execution by replaying the peeked bytes before the remaining stream.
+// The returned bool indicates if the peeked bytes contain SQL migration code.
+func classifyMigrationBody(migr *Migration, maxPeekBytes int) (bool, error) {
+	peekCap := int(migr.BufferSize)
+	if peekCap <= 0 {
+		peekCap = int(DefaultBufferSize)
+	}
+	if peekCap > maxPeekBytes {
+		peekCap = maxPeekBytes
+	}
+
+	// buf is used to read a small prefix of the migration for
+	// classification purposes without holding the whole migration in
+	// memory.
+	buf := make([]byte, peekCap)
+
+	// Read the data from the migration file, capped by the size of buf.
+	n, err := io.ReadFull(migr.BufferedBody, buf)
+	switch {
+	case err == nil:
+	case errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF):
+		// It's expected that we'll read the end of the file, if the
+		// buf size above the size of the migration. In that case, we
+		// continue, and only reset the buf to size of n below.
+	default:
+		return false, fmt.Errorf("read migration body error: %w", err)
+	}
+
+	// Set buf to size of n. If the migr.BufferedBody contained more data
+	// than the peekCap size, then n will already be the capacity of buf.
+	// Else n will be the size of the actual data length.
+	buf = buf[:n]
+
+	// Replay the peeked bytes first, then stream the remaining body to the
+	// driver.
+	migr.BufferedBody = io.MultiReader(
+		bytes.NewReader(buf), migr.BufferedBody,
+	)
+
+	return hasSQLMigration(string(buf))
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,9 +1,33 @@
 package migrate
 
 import (
+	"io"
 	nurl "net/url"
+	"strings"
 	"testing"
 )
+
+// countingReader wraps a byte slice and tracks how much has been read.
+// It lets tests assert how much of the migration was consumed during
+// classification versus execution.
+type countingReader struct {
+	// data holds the underlying content to be read.
+	data []byte
+
+	// read tracks how many bytes have been consumed so far.
+	read int
+}
+
+// Read copies from the underlying byte slice into p and increments the read
+// counter so tests can observe how many bytes were consumed.
+func (c *countingReader) Read(p []byte) (int, error) {
+	if c.read >= len(c.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, c.data[c.read:])
+	c.read += n
+	return n, nil
+}
 
 func TestSuintPanicsWithNegativeInput(t *testing.T) {
 	defer func() {
@@ -31,5 +55,168 @@ func TestFilterCustomQuery(t *testing.T) {
 	}
 	if nx.Get("ok") != "y" {
 		t.Fatalf("expected ok=y, got %v", nx.Get("ok"))
+	}
+}
+
+// TestHasSQLMigration verifies detection of executable SQL vs
+// comments/whitespace. Data is considered to be executable SQL, if the data
+// contains anything else than just comments/whitespace.
+func TestHasSQLMigration(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         string
+		expectHasSQL bool
+	}{
+		{
+			name:         "empty string",
+			data:         "",
+			expectHasSQL: false,
+		},
+		{
+			name:         "whitespace and semicolons only",
+			data:         "\n;\t;\r\n  ;",
+			expectHasSQL: false,
+		},
+		{
+			name:         "only comments",
+			data:         "-- comment line\n/* block comment */\n;",
+			expectHasSQL: false,
+		},
+		{
+			name:         "bom with no statements",
+			data:         "\uFEFF   \n-- just comments\n",
+			expectHasSQL: false,
+		},
+		{
+			name:         "sql only",
+			data:         "INSERT INTO foo VALUES (1);",
+			expectHasSQL: true,
+		},
+		{
+			name:         "sql after comments",
+			data:         "-- comment\nSELECT * FROM users; -- trailing comment",
+			expectHasSQL: true,
+		},
+		{
+			name:         "sql after block comment",
+			data:         "/* header comment */\n\nINSERT INTO foo VALUES (1);",
+			expectHasSQL: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hasSQLMigration(tt.data)
+			if err != nil {
+				t.Fatalf("hasSQLMigration(%q) unexpected "+
+					"error: %v", tt.data, err)
+			}
+			if got != tt.expectHasSQL {
+				t.Fatalf("hasSQLMigration(%q) = %v, want %v",
+					tt.data, got, tt.expectHasSQL)
+			}
+		})
+	}
+}
+
+// TestClassifyMigrationBodyPeeksAndReplays ensures classifyMigrationBody only
+// reads a capped prefix for SQL detection, then replays that prefix followed by
+// the remaining body so the database driver still receives the full migration.
+func TestClassifyMigrationBodyPeeksAndReplays(t *testing.T) {
+	body := "SELECT 1;\n" + strings.Repeat("x", 1024)
+	peekCap := 8
+
+	cr := &countingReader{data: []byte(body)}
+	migr := &Migration{
+		BufferedBody: cr,
+		BufferSize:   uint(peekCap),
+	}
+
+	hasSQL, err := classifyMigrationBody(migr, 16)
+	if err != nil {
+		t.Fatalf("classifyMigrationBody error = %v", err)
+	}
+	if !hasSQL {
+		t.Fatalf("expected SQL migration from prefix, got false")
+	}
+
+	if cr.read != peekCap {
+		t.Fatalf("expected to read %d bytes for classification, "+
+			"read %d", peekCap, cr.read)
+	}
+
+	replayed, err := io.ReadAll(migr.BufferedBody)
+	if err != nil {
+		t.Fatalf("reading replayed body: %v", err)
+	}
+	if string(replayed) != body {
+		t.Fatalf("expected replayed body to equal original, got "+
+			"len=%d want len=%d", len(replayed), len(body))
+	}
+	if cr.read != len(body) {
+		t.Fatalf("expected underlying reader to be fully consumed, "+
+			"read %d want %d", cr.read, len(body))
+	}
+}
+
+// TestClassifyMigrationBodyMissesDeepSQL shows that if SQL appears beyond the
+// peek window, classification returns false, but widening the peek allows
+// detection. It also verifies the full body is preserved for execution and the
+// underlying reader is fully consumed.
+func TestClassifyMigrationBodyMissesDeepSQL(t *testing.T) {
+	longComment := "-- " + strings.Repeat("c", 64)
+	body := longComment + "\nSELECT 1;"
+	peekCap := 16
+	wideCap := len(body)
+
+	cr := &countingReader{data: []byte(body)}
+	migr := &Migration{
+		BufferedBody: cr,
+		BufferSize:   uint(peekCap),
+	}
+
+	hasSQL, err := classifyMigrationBody(migr, peekCap)
+	if err != nil {
+		t.Fatalf("classifyMigrationBody error = %v", err)
+	}
+	if hasSQL {
+		t.Fatalf("expected false when SQL is beyond peek window")
+	}
+	if cr.read != peekCap {
+		t.Fatalf("expected to read %d bytes for classification, "+
+			"read %d", peekCap, cr.read)
+	}
+
+	replayed, err := io.ReadAll(migr.BufferedBody)
+	if err != nil {
+		t.Fatalf("reading replayed body: %v", err)
+	}
+	if string(replayed) != body {
+		t.Fatalf("expected replayed body to equal original, got "+
+			"len=%d want len=%d", len(replayed), len(body))
+	}
+	if cr.read != len(body) {
+		t.Fatalf("expected underlying reader to be fully consumed, "+
+			"read %d want %d", cr.read, len(body))
+	}
+
+	// Rewind classification with a wider peek to prove SQL is found.
+	cr2 := &countingReader{data: []byte(body)}
+	migr2 := &Migration{
+		BufferedBody: cr2,
+		BufferSize:   uint(wideCap),
+	}
+	hasSQLWide, err := classifyMigrationBody(migr2, wideCap)
+	if err != nil {
+		t.Fatalf("classifyMigrationBody (wide) error = %v", err)
+	}
+	if !hasSQLWide {
+		t.Fatalf("expected SQL migration when peek window covers the " +
+			"body")
+	}
+	if cr2.read != wideCap {
+		t.Fatalf("expected to read %d bytes for wide classification, "+
+			"read %d", wideCap, cr2.read)
 	}
 }


### PR DESCRIPTION
This commit modifies the migration framework to re-attempt post-step callbacks if they error during a migration, and won't leave the database version as `dirty`.

**Implemenation approach:**
This is achieved by introducing the concept of a "post-step callback" migration version. Post-step callbacks are their corresponding SQL migration version offset by +1000000000.

During the execution of a post-step callback, the post-step callback migration version will be persisted as the database version. That way, if the post-step callback errors, the version for the database will be the post-step callback version on the next startup. The post-step callback will then be re-attempted before proceeding with the next SQL migration.

**Alternative approach:**
Another solution to the issue, would be to individually track if a post migration has been executed successfully or not in a separate version table for post migrations. I chose not to go for that approach as that would require individual implementation for every database backend type and therefore be a much larger change.

I'm open to change the approach though if reviewers do not prefer the approach implemented by this PR.